### PR TITLE
Implement hot reload support in Marqueer widget by restarting animations on widget updates

### DIFF
--- a/lib/marqueer.dart
+++ b/lib/marqueer.dart
@@ -2,6 +2,7 @@ library marqueer;
 
 import 'dart:async';
 import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -540,6 +541,26 @@ class _MarqueerState extends State<Marqueer> with WidgetsBindingObserver {
     timerWidowResize?.cancel();
 
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant Marqueer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final needsRestart = oldWidget.pps != widget.pps ||
+        oldWidget.direction != widget.direction ||
+        oldWidget.edgeDuration != widget.edgeDuration ||
+        oldWidget.infinity != widget.infinity;
+
+    if (needsRestart) {
+      // kill any in-flight animation/timers and restart the loop
+      stop();
+      // keep current offset, just cancel the animation cleanly
+      if (scrollController.hasClients) {
+        scrollController.jumpTo(scrollController.offset);
+      }
+      if (widget.autoStart) start();
+    }
   }
 
   @override


### PR DESCRIPTION
# Add Hot Reload Support to Marqueer Widget

This PR implements hot reload support for the Marqueer widget, enabling smooth development experience when modifying widget properties during Flutter hot reload.

## Changes
- Added `didUpdateWidget` lifecycle method to detect when key animation properties change
- Automatically restarts animations when critical properties are updated (`pps`, `direction`, `edgeDuration`, `infinity`)
- Preserves current scroll position during widget updates
- Only restarts when `autoStart` is enabled

## Benefits
- Developers can now modify Marqueer properties and see changes immediately during hot reload
- No need to perform full app restart when tweaking animation parameters
- Maintains smooth user experience by preserving scroll state

## Technical Details
- Monitors property changes in `didUpdateWidget`
- Cleanly stops current animations before restarting
- Maintains scroll controller state to prevent jarring position resets
